### PR TITLE
Make routing key configurable

### DIFF
--- a/app/publisher.py
+++ b/app/publisher.py
@@ -12,7 +12,7 @@ class DurableTopicPublisher:
 
     EXCHANGE = os.getenv("SEFT_RABBIT_EXCHANGE", 'message')
     PUBLISH_INTERVAL = 1
-    ROUTING_KEY = "JWT"
+    ROUTING_KEY = os.getenv("SDX_SEFT_PUBLISHER_ROUTING_KEY")
 
     def __init__(self, amqp_url, queue_name, log=None, **kwargs):
         self.log = log or logging.getLogger("sdx.seft")
@@ -100,7 +100,7 @@ class DurableTopicPublisher:
 
     def on_queue_declareok(self, method_frame):
         self.log.info(
-            "Binding %s to %s with %s",
+            "Binding exchange %s to queue %s with  routing key %s",
             self.EXCHANGE, self.queue_name, self.ROUTING_KEY
         )
         self._channel.queue_bind(self.on_bindok, self.queue_name,


### PR DESCRIPTION
The `ROUTING_KEY` variable was previously hardcoded to be 'JWT'. This pull request introduces a configurable version of this variable, which is instantiated using a named environment variable - `SDX_SEFT_PUBLISHER_ROUTING_KEY`.

In cases where this is not set, the default value will be None. In this case, the default Pika behaviour is to use the queue name as the default routing key when binding to a topic exchange. See http://pika.readthedocs.io/en/0.10.0/_modules/pika/channel.html#Channel.queue_bind for the implementation.