### PR TITLE
Fix/deleting all files on queue reconnect

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -41,8 +41,8 @@ class Task:
             uri = "amqp://{user}:{password}@{hostname}:{port}/{vhost}".format(
                 hostname=os.getenv("SEFT_RABBITMQ_HOST", "localhost"),
                 port=os.getenv("SEFT_RABBITMQ_PORT", 5672),
-                user=os.getenv("SEFT_RABBITMQ_DEFAULT_USER", "rabbit"),
-                password=os.getenv("SEFT_RABBITMQ_DEFAULT_PASS", "rabbit"),
+                user=os.getenv("SEFT_RABBITMQ_DEFAULT_USER", "guest"),
+                password=os.getenv("SEFT_RABBITMQ_DEFAULT_PASS", "guest"),
                 vhost=os.getenv("SEFT_RABBITMQ_DEFAULT_VHOST", "%2f")
             )
         return {
@@ -81,10 +81,10 @@ class Task:
     @staticmethod
     def ftp_params(services):
         return {
-            "user": os.getenv("SEFT_FTP_USER", "user"),
-            "password": os.getenv("SEFT_FTP_PASS", "password"),
+            "user": os.getenv("SEFT_FTP_USER", "ons"),
+            "password": os.getenv("SEFT_FTP_PASS", "ons"),
             "host": os.getenv("SEFT_FTP_HOST", "127.0.0.1"),
-            "port": int(os.getenv("SEFT_FTP_PORT", 2121)),
+            "port": int(os.getenv("SEFT_FTP_PORT", 2021)),
             "working_directory": os.getenv("SEFT_PUBLISHER_FTP_FOLDER", "/")
         }
 
@@ -121,10 +121,12 @@ class Task:
 
             now = datetime.datetime.utcnow()
             for fn, (ts, msg_id) in self.recent.copy().items():
-                if msg_id not in self.publisher._deliveries:
+                if msg_id in self.publisher._deliveries:
                     active.delete(fn)
                     log.info("Deleted {0}".format(fn))
-                if now - ts > datetime.timedelta(hours=1):
+
+                refresh_time = 2 * int(os.getenv("SEFT_FTP_INTERVAL_MS", 60 * 1000))
+                if now - ts > datetime.timedelta(milliseconds=refresh_time):
                     del self.recent[fn]
 
 
@@ -162,7 +164,7 @@ def main(args):
     app.listen(args.port)
 
     # Create the scheduled task
-    interval_ms = int(os.getenv("SEFT_FTP_INTERVAL_MS", 30 * 60 * 1000))
+    interval_ms = int(os.getenv("SEFT_FTP_INTERVAL_MS", 60 * 1000))
     task = Task(args, services)
     sched = tornado.ioloop.PeriodicCallback(
         task.transfer_files,

--- a/app/publisher.py
+++ b/app/publisher.py
@@ -130,9 +130,9 @@ class DurableTopicPublisher:
             self._acked += 1
         elif confirmation_type == "nack":
             self._nacked += 1
-        self._deliveries.remove(method_frame.method.delivery_tag)
+        self._deliveries.append(method_frame.method.delivery_tag)
         self.log.info(
-            "Published %i messages, %i have yet to be confirmed, "
+            "Published %i messages, %i have been confirmed, "
             "%i were acked and %i were nacked",
             self._message_number, len(self._deliveries),
             self._acked, self._nacked
@@ -160,7 +160,6 @@ class DurableTopicPublisher:
             self.EXCHANGE, self.ROUTING_KEY, message, properties
         )
         self._message_number += 1
-        self._deliveries.append(self._message_number)
         self.log.info("Published message # %i", self._message_number)
         return self._message_number
 


### PR DESCRIPTION
There was an issue where all files were deleted if the publisher service reconnects to the queue.