### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### Unreleased
+
+### 1.0.0
   - Explicitly add `mandatory=True` and `immediate=False` to the call to self._channel.basic_publish in `app.publisher`.
   - Use struct logger and convert to python module
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from structlog.processors import JSONRenderer
 from structlog.stdlib import filter_by_level, add_log_level
 
 
-__version__ = "0.1.1"
+__version__ = "1.0.0"
 __service__ = "sdx-seft-publisher-service"
 
 


### PR DESCRIPTION
 - Explicitly add `mandatory=True` and `immediate=False` to the call to self._channel.basic_publish in `app.publisher`.
  - Use struct logger and convert to python module