### PR TITLE
Adding dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+.*
+.git
+.dockerignore
+Dockerfile
+
+
+# Python temp files
+*.pyc
+*/__pycache__*
+
+.idea
+
+# Virtualenvs
+env
+env*
+venv
+
+*.tox
+*.ini
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6
 
-WORKDIR /
-COPY . /
+WORKDIR /app
+COPY . /app
 
 EXPOSE 8086
 RUN pip3 install --require-hashes -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.6
+
+WORKDIR /app
+COPY . /app
+COPY app/test/test_no_password.pem /app/test
+COPY app/test/test_no_password.pub /app/test
+
+EXPOSE 8086
+RUN pip3 install --require-hashes -r requirements.txt
+
+CMD  ["python3","main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM python:3.6
-
 WORKDIR /app
-COPY . /app
-
 EXPOSE 8086
-RUN pip3 install --require-hashes -r requirements.txt
-
 CMD  ["python3","main.py"]
+COPY requirements.txt /app/requirements.txt
+RUN pip3 install --require-hashes -r requirements.txt
+COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.6
 
-WORKDIR /app
-COPY . /app
-COPY app/test/test_no_password.pem /app/test
-COPY app/test/test_no_password.pub /app/test
+WORKDIR /
+COPY . /
+COPY app/test/test_no_password.pem /test
+COPY app/test/test_no_password.pub /test
 
 EXPOSE 8086
 RUN pip3 install --require-hashes -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM python:3.6
 
 WORKDIR /
 COPY . /
-COPY app/test/test_no_password.pem /test
-COPY app/test/test_no_password.pub /test
 
 EXPOSE 8086
 RUN pip3 install --require-hashes -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,5 @@ test: build
 	flake8 --exclude lib .
 	python3 -m unittest app/test/test_*.py
 
+start:
+	python main.py

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python3 -m app.main
+web: python3 -m main

--- a/README.md
+++ b/README.md
@@ -12,7 +12,40 @@ Once the internal systems are fully redeveloped this service will be either reti
 
 ## Getting started
 
-_TBD_
+To install, use:
+```
+make build
+```
+To run the tests, use:
+```
+make test
+```
+## Usage
+### Using Docker compose
+
+You can run this service using the docker compose file in [sdc-ci-upload-compose](https://github.com/ONSdigital/sdc-ci-upload-compose/tree/update-env-vars-for-rabbit-adapter) and running `docker compose up -d`. This will run all the necessary services that
+it needs to communicate with. All you will need to do then is put a xlxs file inside the `Documents/ftp` directory and file should be put on the FTP.
+
+### Running Standalone
+
+You can run this service on its own but to do so, some changes will have to be made to environment variables such as `SEFT_FTP_PORT` and `SEFT_PUBLISHER_FTP_FOLDER`. This service also needs
+to communicate with an FTP server and a Rabbit queue, so these services will need to be created in order to upload files correctly. Down below is an example of the variables that need to be changed to connect to the
+FTP.
+
+| Environment variable          | FTP Changes   | Description
+| --------------------          | -------   | -----------
+| SEFT_FTP_PORT                 | 21 |        Local FTP port
+| SEFT_PUBLISHER_FTP_FOLDER     | Documents/ftp | Example FTP folder
+| SEFT_FTP_USER     | user | Example username for FTP
+| SEFT_FTP_PASS     | pass | Example password for FTP
+
+
+
+To start the service, use the command:
+```
+python main.py
+```
+
 
 ## Configuration
 
@@ -36,8 +69,6 @@ _TBD_
 
 _TBC_
 
-## Run
-python -m app.main
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -23,23 +23,15 @@ make test
 ## Usage
 ### Using Docker compose
 
-You can run this service using the docker compose file in [sdc-ci-upload-compose](https://github.com/ONSdigital/sdc-ci-upload-compose/tree/update-env-vars-for-rabbit-adapter) and running `docker compose up -d`. This will run all the necessary services that
+You can run this service using the docker compose file in [sdc-ci-upload-compose](https://github.com/ONSdigital/sdc-ci-upload-compose) and running `docker compose up -d`. This will run all the necessary services that
 it needs to communicate with. All you will need to do then is put a xlxs file inside the `Documents/ftp` directory and file should be put on the FTP.
 
 ### Running Standalone
 
 You can run this service on its own but to do so, some changes will have to be made to environment variables such as `SEFT_FTP_PORT` and `SEFT_PUBLISHER_FTP_FOLDER`. This service also needs
-to communicate with an FTP server and a Rabbit queue, so these services will need to be created in order to upload files correctly. Down below is an example of the variables that need to be changed to connect to the
-FTP.
-
-| Environment variable          | FTP Changes   | Description
-| --------------------          | -------   | -----------
-| SEFT_FTP_PORT                 | 21 |        Local FTP port
-| SEFT_PUBLISHER_FTP_FOLDER     | Documents/ftp | Example FTP folder
-| SEFT_FTP_USER     | user | Example username for FTP
-| SEFT_FTP_PASS     | pass | Example password for FTP
-
-
+to communicate with an FTP server and a Rabbit queue, so these services will need to be created in order to upload files correctly. If you want to do so, your best option is to go to
+[sdc-ci-upload-compose](https://github.com/ONSdigital/sdc-ci-upload-compose) and run `docker-compose up -d sdx-seft-publisher-service`. This will build all the services that sdx-seft-publisher
+needs to run and pull a file from an FTP and put it on a Rabbit queue.
 
 To start the service, use the command:
 ```

--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@ it needs to communicate with. All you will need to do then is put a xlxs file in
 
 ### Running Standalone
 
-You can run this service on its own but to do so, some changes will have to be made to environment variables such as `SEFT_FTP_PORT` and `SEFT_PUBLISHER_FTP_FOLDER`. This service also needs
-to communicate with an FTP server and a Rabbit queue, so these services will need to be created in order to upload files correctly. If you want to do so, your best option is to go to
+You can run this service on its own but to do so, a FTP server and a Rabbit queue need to be created to communicate with it. If you want to run it on its own, your best option is to go to
 [sdc-ci-upload-compose](https://github.com/ONSdigital/sdc-ci-upload-compose) and run `docker-compose up -d sdx-seft-publisher-service`. This will build all the services that sdx-seft-publisher
-needs to run and pull a file from an FTP and put it on a Rabbit queue.
+needs to run, pull a file from an FTP and put it on a Rabbit queue.
 
 To start the service, use the command:
 ```
-python main.py
+make start
 ```
 
 

--- a/app/test/test_task.py
+++ b/app/test/test_task.py
@@ -6,7 +6,7 @@ import unittest
 import tornado.concurrent
 import tornado.ioloop
 
-from app.main import Task
+from main import Task
 from app.test.localserver import serve
 from app.test.test_ftp import NeedsTemporaryDirectory
 from app.test.test_ftp import ServerTests

--- a/app/test/test_task.py
+++ b/app/test/test_task.py
@@ -6,10 +6,10 @@ import unittest
 import tornado.concurrent
 import tornado.ioloop
 
-from main import Task
 from app.test.localserver import serve
 from app.test.test_ftp import NeedsTemporaryDirectory
 from app.test.test_ftp import ServerTests
+from main import Task
 
 
 class TaskTests(NeedsTemporaryDirectory, unittest.TestCase):

--- a/main.py
+++ b/main.py
@@ -204,7 +204,7 @@ def parser(description="SEFT Publisher service."):
     here = os.path.dirname(__file__)
     p = argparse.ArgumentParser(description)
     p.add_argument(
-        "--keys", default=os.path.abspath(os.path.join(here, "app/test")),
+        "--keys", default=os.path.abspath(os.path.join(here, "test")),
         help="Set a path to the keypair directory.")
     p.add_argument(
         "--port", type=int, default=int(os.getenv("SDX_SEFT_PUBLISHER_PORT", "8087")),

--- a/main.py
+++ b/main.py
@@ -122,8 +122,8 @@ class Task:
             "user": os.getenv("SEFT_FTP_USER", "ons"),
             "password": os.getenv("SEFT_FTP_PASS", "ons"),
             "host": os.getenv("SEFT_FTP_HOST", "127.0.0.1"),
-            "port": int(os.getenv("SEFT_FTP_PORT", 2021)),
-            "working_directory": os.getenv("SEFT_PUBLISHER_FTP_FOLDER", "/")
+            "port": int(os.getenv("SEFT_FTP_PORT", 21)),
+            "working_directory": os.getenv("SEFT_PUBLISHER_FTP_FOLDER", "/Ftp")
         }
 
     def __init__(self, args, services):
@@ -204,10 +204,10 @@ def parser(description="SEFT Publisher service."):
     here = os.path.dirname(__file__)
     p = argparse.ArgumentParser(description)
     p.add_argument(
-        "--keys", default=os.path.abspath(os.path.join(here, "test")),
+        "--keys", default=os.path.abspath(os.path.join(here, "app/test")),
         help="Set a path to the keypair directory.")
     p.add_argument(
-        "--port", type=int, default=int(os.getenv("SDX_SEFT_PUBLISHER_PORT", "8080")),
+        "--port", type=int, default=int(os.getenv("SDX_SEFT_PUBLISHER_PORT", "8087")),
         help="Set a port for the service.")
     return p
 

--- a/main.py
+++ b/main.py
@@ -207,7 +207,7 @@ def parser(description="SEFT Publisher service."):
         "--keys", default=os.path.abspath(os.path.join(here, "test")),
         help="Set a path to the keypair directory.")
     p.add_argument(
-        "--port", type=int, default=int(os.getenv("SDX_SEFT_PUBLISHER_PORT", "8087")),
+        "--port", type=int, default=int(os.getenv("SDX_SEFT_PUBLISHER_PORT", "8080")),
         help="Set a port for the service.")
     return p
 

--- a/main.py
+++ b/main.py
@@ -91,7 +91,6 @@ class Task:
 
     @staticmethod
     def encrypt_params(services, locn="."):
-        log.info("Encrypt params")
         pub_fp = os.getenv("RAS_SEFT_PUBLISHER_PUBLIC_KEY",
                            os.path.join(locn, "test_no_password.pub"))
         priv_fp = os.getenv("SDX_SEFT_PUBLISHER_PRIVATE_KEY",
@@ -115,7 +114,6 @@ class Task:
             "public_key": pub_key,
             "private_key": priv_key,
         }
-        log.info("End of encrypt_params")
         return rv
 
     @staticmethod
@@ -161,13 +159,9 @@ class Task:
         try:
             log.info("Looking for files...")
             worker = FTPWorker(**self.ftp_params(self.services))
-            log.info("So its signed in successfully")
-            log.info(self.services)
-            log.info(self.ar)
             encrypter = Encrypter(**self.encrypt_params(self.services, locn=self.args.keys))
             with worker as active:
                 if not active:
-                    log.info("Worker not active")
                     return
 
                 for job in active.get(active.filenames):

--- a/main.py
+++ b/main.py
@@ -91,6 +91,7 @@ class Task:
 
     @staticmethod
     def encrypt_params(services, locn="."):
+        log.info("Encrypt params")
         pub_fp = os.getenv("RAS_SEFT_PUBLISHER_PUBLIC_KEY",
                            os.path.join(locn, "test_no_password.pub"))
         priv_fp = os.getenv("SDX_SEFT_PUBLISHER_PRIVATE_KEY",
@@ -114,6 +115,7 @@ class Task:
             "public_key": pub_key,
             "private_key": priv_key,
         }
+        log.info("End of encrypt_params")
         return rv
 
     @staticmethod
@@ -122,8 +124,8 @@ class Task:
             "user": os.getenv("SEFT_FTP_USER", "ons"),
             "password": os.getenv("SEFT_FTP_PASS", "ons"),
             "host": os.getenv("SEFT_FTP_HOST", "127.0.0.1"),
-            "port": int(os.getenv("SEFT_FTP_PORT", 21)),
-            "working_directory": os.getenv("SEFT_PUBLISHER_FTP_FOLDER", "/Ftp")
+            "port": int(os.getenv("SEFT_FTP_PORT", 2021)),
+            "working_directory": os.getenv("SEFT_PUBLISHER_FTP_FOLDER", "/")
         }
 
     def __init__(self, args, services):
@@ -159,9 +161,13 @@ class Task:
         try:
             log.info("Looking for files...")
             worker = FTPWorker(**self.ftp_params(self.services))
+            log.info("So its signed in successfully")
+            log.info(self.services)
+            log.info(self.ar)
             encrypter = Encrypter(**self.encrypt_params(self.services, locn=self.args.keys))
             with worker as active:
                 if not active:
+                    log.info("Worker not active")
                     return
 
                 for job in active.get(active.filenames):


### PR DESCRIPTION
## Motivation and Context
For the upcoming BRES survey, sdx-seft-publisher is used to pull a file from a FTP, encrypt it and pass it through to a rabbit queue. The purpose of this PR is to add a Dockerfile so it can be run more easily with the other services

## What has changed
- Added a Dockerfile
- Moved main out of the app directory 

## How to test
- Build the image - `docker build -t sdcplatform/sdx-seft-publisher-service .`
- Create an ftp folder inside of your Documents directory and put a collection instrument in there. Can find one in the [acceptance test resources directory.](https://github.com/ONSdigital/rasrm-acceptance-tests/blob/master/resources/collection_instrument_files/064_201803_0001.xlsx)
- Easiest way to test this is to do `docker-compose up -d sdx-seft-publisher-service` on [sdc-ci-upload-compose](https://github.com/ONSdigital/sdc-ci-upload-compose) and it should run and should pull from the ftp and put it on the queue.